### PR TITLE
[PR] Variable reference

### DIFF
--- a/custom-javascript-editor.php
+++ b/custom-javascript-editor.php
@@ -121,9 +121,10 @@ class Custom_Javascript_Editor {
 			'post_status' => 'publish',
 		);
 
-		if ( $post = array_shift( get_posts( $args ) ) )
+		$posts = get_posts( $args );
+		if ( $post = array_shift( $posts ) )
 			return get_object_vars( $post );
-		
+
 		return false;
 	}
 


### PR DESCRIPTION
This shows a notice in PHP 7.0. Instead, we can capture the value of `get_posts()` and immediately pass that variable.